### PR TITLE
Offset in settings

### DIFF
--- a/src/js/wizard.js
+++ b/src/js/wizard.js
@@ -171,8 +171,8 @@
 			//Offsets
 			offsetLeft            : 4,
 			offsetTop             : 5,
-			offsetRight           : 10,
-			offsetBottom          : 10,
+			offsetRight           : 6,
+			offsetBottom          : 5,
 
 			//Callbacks :: Wizard
 			onWizardStart         : $.noop,
@@ -1703,12 +1703,17 @@
 			{
 				var object = struct.object;
 				var step = this.getCurrentStep();
+				
+				var counted_x = (step.offsetLeft || this.settings.offsetLeft);
+				var counted_y = (step.offsetTop || this.settings.offsetTop);
+				var counted_w = (step.offsetRight || this.settings.offsetRight) + counted_x;
+				var counted_h = (step.offsetBottom || this.settings.offsetBottom) + counted_y;
 	
 				var offset = object.offset();
-				var x = parseInt(offset.left)-(step.offsetLeft || this.settings.offsetLeft);
-				var y = parseInt(offset.top)-(step.offsetTop || this.settings.offsetTop);
-				var w = parseInt(object.outerWidth())+(step.offsetRight || this.settings.offsetRight);
-				var h = parseInt(object.outerHeight())+(step.offsetBottom || this.settings.offsetBottom);
+				var x = parseInt(offset.left)-counted_x;
+				var y = parseInt(offset.top)-counted_y;
+				var w = parseInt(object.outerWidth())+counted_w;
+				var h = parseInt(object.outerHeight())+counted_h;
 	
 				//change in offset?
 				if (

--- a/src/js/wizard.js
+++ b/src/js/wizard.js
@@ -168,6 +168,11 @@
 			finishLabel           : '<i class="fa fa-fw fa-flag-checkered"></i>',
 			closeLabel            : '<i class="fa fa-fw fa-times"></i>',
 			headerTemplate        : '{{step}}/{{steps}}',
+			//Offsets
+			offsetLeft            : 4,
+			offsetTop             : 5,
+			offsetRight           : 10,
+			offsetBottom          : 10,
 
 			//Callbacks :: Wizard
 			onWizardStart         : $.noop,
@@ -1697,12 +1702,13 @@
 			else
 			{
 				var object = struct.object;
+				var step = this.getCurrentStep();
 	
 				var offset = object.offset();
-				var x = parseInt(offset.left)-4;
-				var y = parseInt(offset.top)-5;
-				var w = parseInt(object.outerWidth())+10;
-				var h = parseInt(object.outerHeight())+10;
+				var x = parseInt(offset.left)-(step.offsetLeft || this.settings.offsetLeft);
+				var y = parseInt(offset.top)-(step.offsetTop || this.settings.offsetTop);
+				var w = parseInt(object.outerWidth())+(step.offsetRight || this.settings.offsetRight);
+				var h = parseInt(object.outerHeight())+(step.offsetBottom || this.settings.offsetBottom);
 	
 				//change in offset?
 				if (


### PR DESCRIPTION
Allow specifying the offset between the glowing frame and highlighted page element. The new values can be given in wizard settings (globally) or in step definition.
Different elements on the page might have different paddings, which is also counted into the element's dimensions, so specifying it manually is a must in some cases.

This change only gives a possibility of changing the offset manually, the default values are like the previously hardcoded:
- left: 4
- top: 5
- right: 6 (width offset was 10)
- bottom: 5 (height offset was 10)
